### PR TITLE
Temporarily hide dead links

### DIFF
--- a/src/components/Navigation/DesktopNavigation.vue
+++ b/src/components/Navigation/DesktopNavigation.vue
@@ -5,7 +5,7 @@
                 li(v-bind:class="{isActive: currentPath === route.path}")
                     router-link.u-block.u-color-blue-dark.u-text-weight-bold.u-text-family-secondary(v-on:click.native='handleNavToggle', v-bind:to='route.path')
                         | {{ route.name }}
-        ul.c-nav-crumbs__minor.u-context.u-text-size-base
+        // ul.c-nav-crumbs__minor.u-context.u-text-size-base
             li
                 router-link.u-block.u-color-purple-medium(v-on:click.native='handleNavToggle', to='/contact')
                     | Contact us

--- a/src/components/Navigation/MobileNavigation.vue
+++ b/src/components/Navigation/MobileNavigation.vue
@@ -19,7 +19,7 @@
                 li(v-bind:class="{isActive: currentPath === route.path}")
                     router-link.u-block.u-color-blue-dark.u-text-weight-bold.u-text-family-secondary(v-on:click.native='handleNavToggle', v-bind:to='route.path')
                         | {{ route.name }}
-        ul.c-nav-crumbs__minor.u-context.u-text-size-base
+        // ul.c-nav-crumbs__minor.u-context.u-text-size-base
             li
                 router-link.u-color-purple-medium(v-on:click.native='handleNavToggle', to='/contact')
                     | Contact us

--- a/src/components/globalFooter.vue
+++ b/src/components/globalFooter.vue
@@ -32,12 +32,16 @@ footer.u-bg-black.u-color-white.u-context.u-clip.u-padding-bottom-medium.u-paddi
 
             h2.u-visually-hidden More Links:
             nav.u-flexbox--narrow-up.u-margin-bottom-base.u-justify-end--medium-up.u-text-size-small.u-text-align-center.u-baseline-small
-                router-link.u-block(v-on:click.native='handleNavToggle' to='/vision-values')
+                // router-link.u-block(v-on:click.native='handleNavToggle' to='/vision-values')
                     | Vision &amp; Values
-                router-link.u-block(v-on:click.native='handleNavToggle' to='/privacy-security')
+                // router-link.u-block(v-on:click.native='handleNavToggle' to='/privacy-security')
                     | Privacy &amp; Security
-                router-link.u-block(v-on:click.native='handleNavToggle' to='/xxxxx')
+                a.u-block(href='https://paper.dropbox.com/doc/Our-Code-of-Conduct-j62RafLNgIaUjUsOGeVwA')
                     | Code of Conduct
+                a.u-block(href='https://linkedin.com/company/house-house')
+                    | LinkedIn
+                a.u-block(href='https://github.com/househouse')
+                    | GitHub
 
             div.u-margin-bottom-base.u-color-grey-dark.u-text-align-left.u-text-align-right--medium-up.u-text-size-small.u-baseline-small
                 p

--- a/src/components/globalFooter.vue
+++ b/src/components/globalFooter.vue
@@ -36,12 +36,12 @@ footer.u-bg-black.u-color-white.u-context.u-clip.u-padding-bottom-medium.u-paddi
                     | Vision &amp; Values
                 // router-link.u-block(v-on:click.native='handleNavToggle' to='/privacy-security')
                     | Privacy &amp; Security
-                a.u-block(href='https://paper.dropbox.com/doc/Our-Code-of-Conduct-j62RafLNgIaUjUsOGeVwA')
-                    | Code of Conduct
                 a.u-block(href='https://linkedin.com/company/house-house')
                     | LinkedIn
                 a.u-block(href='https://github.com/househouse')
                     | GitHub
+                a.u-block(href='https://paper.dropbox.com/doc/Our-Code-of-Conduct-j62RafLNgIaUjUsOGeVwA')
+                    | Our Code of Conduct
 
             div.u-margin-bottom-base.u-color-grey-dark.u-text-align-left.u-text-align-right--medium-up.u-text-size-small.u-baseline-small
                 p


### PR DESCRIPTION
Until we have content for _Vision_ and _Privacy_, we will hide these dead-end links from the main navigation and footer.

I added in links to social media in the footer to keep the same slant/angle of negative space to the left.

- https://trello.com/c/cRgdpo8z/24-footer-%E2%96%B8-dead-link-code-of-conduct
- https://trello.com/c/w7hSnw0X/25-nav-%E2%96%B8-dead-links

