### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/google98759179463b740b.html
+++ b/google98759179463b740b.html
@@ -1,0 +1,1 @@
+google-site-verification: google98759179463b740b.html

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 
     <!-- Looking for Site content metadata? Check `metaInfo` in App.vue -->
+    <meta name="google-site-verification" content="XQrarlvRzShmAo5O_AzT_Wuinw1JiNI4IXWGltMtxkA" />
 
     <!-- METADATA CONTENT-->
     <meta name="twitter:card" content="summary_large_image" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,6 @@ export default {
     titleTemplate: '%s • A Design Studio', // all titles will be injected into this template
     meta: [
       { charset: 'utf-8' },
-      { name: 'google-site-verification', content: 'XQrarlvRzShmAo5O_AzT_Wuinw1JiNI4IXWGltMtxkA' },
       { name: 'description', content: 'A design studio and freelancer community' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { name: 'author', content: 'Ben Groulx, Sean Durfee' },


### PR DESCRIPTION
This PR adds the Google Search Console verification file, necessary to prove we are owners of the site, and giving us insights via Search Console.

Learn more: https://support.google.com/webmasters/answer/9008080

***

https://www.notion.so/househouse/Google-Search-Console-verification-903a0ef6e6204d9f9b1738a9c5453d48